### PR TITLE
toc bump for 11.2

### DIFF
--- a/SimpleCombatLogger.toc
+++ b/SimpleCombatLogger.toc
@@ -1,8 +1,8 @@
-## Interface: 110100
+## Interface: 110200
 ## Title: SimpleCombatLogger
 ## Notes: Automatically combat log for certain instance types and difficulties
 ## Author: Chris Sutcliff
-## Version: 1.6.12
+## Version: 1.6.13
 ## SavedVariables: SimpleCombatLoggerDB
 ## OptionalDeps: Ace3
 ## X-Curse-Project-ID: 457620


### PR DESCRIPTION
toc bump for 11.2

have checked that the out of date warning is resolved

not tested it yet, but almost certainly all is fine, i'll report back if not :)

<img width="701" height="631" alt="{7C284D19-DF65-4029-8956-F27FACB49341}" src="https://github.com/user-attachments/assets/226779c4-0c45-4aca-895f-f190f0970a06" />
