### PR TITLE
add Addon Category

### DIFF
--- a/SimpleCombatLogger.toc
+++ b/SimpleCombatLogger.toc
@@ -6,6 +6,7 @@
 ## SavedVariables: SimpleCombatLoggerDB
 ## OptionalDeps: Ace3
 ## X-Curse-Project-ID: 457620
+## Category: Combat
 
 embeds.xml
 Main.lua


### PR DESCRIPTION
This will add the addon to the category displayed on the addon overview:
<img width="353" height="172" alt="{FEB8C5A5-BDA2-462E-A95E-6878189D4DDC}" src="https://github.com/user-attachments/assets/a0344d2a-6074-4d9f-a96f-23e33a3eddf9" />

There are some default values for these categories, feel free to suggest a different one:
https://warcraft.wiki.gg/wiki/Addon_Categories#Combat